### PR TITLE
fix: disruption does not have key `streckennummern`

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,7 +16,8 @@ function formatDateTime(isoString) {
 
 function createResponseJSON(inJSON) {
     return inJSON.filter(d => !d.abgelaufen
-        && (d.streckennummern.includes(4010) || d.streckennummern.includes(4011))) // fix for disruptions for whole regions which have no track number
+        && (d.betriebsstellen.length > 0 || d.abschnitte > 0)
+    )
     .map(d => ({
         head: d.subcause !== '' ? `${d.cause} - ${d.subcause}` : cause,
         text: d.text,


### PR DESCRIPTION
Fixes the error `TypeError: Cannot read properties of undefined (reading 'includes')`. Checking for `d.betriebsstellen > 0 || d.abschnitte > 0` to prevent region disruption should be enough.